### PR TITLE
feat: 添加书架功能，支持书籍管理与同步

### DIFF
--- a/src/frontend/books/Books.tsx
+++ b/src/frontend/books/Books.tsx
@@ -6,16 +6,18 @@
  */
 import * as React from 'react';
 import ColorHash from 'color-hash'
-import {IconButton, Modal} from 'hana-ui';
+import { IconButton, Modal, Select, Option } from 'hana-ui';
 
 import bk from '../../backend';
-import {IBook} from '../../interfaces/protocols';
-import {Menu} from './Menu';
-import {ISystemSettings} from '../../interfaces';
+import { IBook, IBookConfig } from '../../interfaces/protocols';
+import { Menu } from './Menu';
+import { ISystemSettings } from '../../interfaces';
 
 import css from '../styles/books.module.scss';
+import webdav from '../webdav';
 
 export interface IBooksProps {
+  bookshelfMapState: [{ [hash: string]: string }, React.Dispatch<React.SetStateAction<{ [hash: string]: string }>>];
   settings: ISystemSettings;
   books: IBook[];
   onSelect(index: number): void;
@@ -29,17 +31,29 @@ export interface IBooksProps {
 export default function Books(props: IBooksProps) {
   const [showDelete, setShowDelete] = React.useState<boolean>(false);
   const [bookDelete, setBookDelete] = React.useState<IBook>();
+  const [isOnAddToBookshelf, setIsOnAddToBookshelf] = React.useState<boolean>(false);
+  const [addToBookshelfBook, setAddToBookshelfBook] = React.useState<string>();
+  const [bookAddToBookshelf, setBookAddToBookshelf] = React.useState<IBook>();
+  const [selectedBookshelf, setSelectedBookshelf] = React.useState<string>(null);
+  const [bookshelfMap, setBookshelfMap] = props.bookshelfMapState;
+  const [bookshelfList, setBookshelfList] = React.useState<string[]>(Array.from(new Set(props.books.map(b => bookshelfMap[b.hash]).filter(bs => !!bs))));
+
+  React.useEffect(() => {
+    setBookshelfList(Array.from(new Set(props.books.map(b => bookshelfMap[b.hash]).filter(bs => !!bs))));
+  }, [props.books, bookshelfMap]);
 
   return (
     <div className={css.books}>
       <Menu
+        bookshelfListState={[bookshelfList, setBookshelfList]}
+        selectedBookshelfState={[selectedBookshelf, setSelectedBookshelf]}
         settings={props.settings}
         onUpdateSettings={props.onUpdateSettings}
         onAddBooks={props.onAddBooks}
         onSync={props.onSync}
       />
       <div className={css.list}>
-        {props.books.map((book, index) => !book.removed && (
+        {props.books.map((book, index) => !book.removed && (bookshelfMap[book.hash] == selectedBookshelf) && (
           <Book
             key={book.hash}
             book={book}
@@ -53,6 +67,10 @@ export default function Books(props: IBooksProps) {
             onImportNotes={() => {
               props.onImportBookNotes(book)
             }}
+            onAddToBookshelf={() => {
+              setIsOnAddToBookshelf(true);
+              setBookAddToBookshelf(book);
+            }}
           />
         ))}
       </div>
@@ -60,8 +78,8 @@ export default function Books(props: IBooksProps) {
       <Modal
         show={showDelete}
         title='确认删除书籍？'
-        titleStyle={{color: 'red'}}
-        contentStyle={{color: 'red'}}
+        titleStyle={{ color: 'red' }}
+        contentStyle={{ color: 'red' }}
         confirm={() => {
           setShowDelete(false);
           props.onRemoveBook(bookDelete);
@@ -72,6 +90,85 @@ export default function Books(props: IBooksProps) {
         <p>包括服务端副本，并会同步给所有终端。</p>
         <p>但笔记将会保留，再次添加相同书籍可恢复。</p>
       </Modal>
+
+      {/* 添加到书架 */}
+      <Modal
+        show={isOnAddToBookshelf}
+        title='添加到书架'
+        confirm={async () => {
+          setIsOnAddToBookshelf(false);
+          try {
+            const configPath = `${bookAddToBookshelf.hash}/config.json`;
+            let config: IBookConfig
+            const exists = await bk.worker.fs.exists(configPath, 'Books');
+            if (exists) {
+              const configStr = await bk.worker.fs.readFile(configPath, 'utf8', 'Books') as string;
+              config = JSON.parse(configStr);
+            } else {
+              config = {
+                ts: Date.now(),
+                lastProgress: 0,
+                progress: 0,
+                bookmarks: [],
+                notes: []
+              };
+            }
+
+            if (bookAddToBookshelf && addToBookshelfBook) {
+              config.ts = Date.now();
+              if (addToBookshelfBook === '默认书架') {
+                config.bookshelf = {
+                  value: null,
+                  ts: Date.now()
+                }
+                setBookshelfMap(m => ({
+                  ...m,
+                  [bookAddToBookshelf.hash]: null
+                }));
+              } else {
+                config.bookshelf = {
+                  value: addToBookshelfBook,
+                  ts: Date.now()
+                };
+                setBookshelfMap(m => ({
+                  ...m,
+                  [bookAddToBookshelf.hash]: addToBookshelfBook
+                }));
+              }
+              await bk.worker.fs.writeFile(configPath, JSON.stringify(config), 'Books');
+              await webdav.syncBookshelf(bookAddToBookshelf, config);
+            }
+          } catch (e) {
+            console.error(e);
+          }
+          setAddToBookshelfBook(undefined);
+          setBookAddToBookshelf(undefined);
+        }}
+        cancel={() => setIsOnAddToBookshelf(false)}
+      >
+        <p>书籍《{bookAddToBookshelf?.name}》将会被移动到书架。</p>
+        <br />
+        <Select
+          defaultLabel='选择书架'
+          auto
+          onSelect={(value) => {
+            setAddToBookshelfBook(value);
+          }}
+        >
+          <Option
+            key='none'
+            label='默认书架'
+            value={'默认书架'}
+          />
+          {bookshelfList.map(bs => (
+            <Option
+              key={bs}
+              label={bs}
+              value={bs}
+            />
+          ))}
+        </Select>
+      </Modal>
     </div>
   );
 }
@@ -81,6 +178,7 @@ interface IBookProps {
   onSelect(): void;
   onDelete(): void;
   onImportNotes(): void;
+  onAddToBookshelf(): void;
 }
 
 const colorHash = new ColorHash();
@@ -110,6 +208,11 @@ function Book(props: IBookProps) {
       {
         bk.supportAddDeleteBook && (
           <div className={css.bookActions}>
+            <IconButton
+              type='menu'
+              size='large'
+              onClick={props.onAddToBookshelf}
+            />
             <IconButton
               type='offline'
               size='large'

--- a/src/frontend/books/Menu.tsx
+++ b/src/frontend/books/Menu.tsx
@@ -5,14 +5,16 @@
  * @Date   : 2022/9/16 23:12:38
  */
 import * as React from 'react';
-import {ButtonGroup, Button, Modal, Form, FormItem, Text, FormGroup} from 'hana-ui';
+import { ButtonGroup, Button, Modal, Form, FormItem, Text, FormGroup, Sidebar, MenuItem, Icon } from 'hana-ui';
 
 import bk from '../../backend';
-import {ISystemSettings} from '../../interfaces';
-import {selectBook, selectFolder} from '../utils';
+import { ISystemSettings } from '../../interfaces';
+import { selectBook, selectFolder } from '../utils';
 import css from '../styles/books.module.scss';
 
 interface IMenuProps {
+  bookshelfListState: [string[], React.Dispatch<React.SetStateAction<string[]>>];
+  selectedBookshelfState: [string, React.Dispatch<React.SetStateAction<string>>];
   settings: ISystemSettings;
   onUpdateSettings(settings: ISystemSettings): void;
   onAddBooks(files: string[]): void;
@@ -25,6 +27,11 @@ export function Menu(props: IMenuProps) {
   const [showConfirm, setShowConfirm] = React.useState<boolean>(false);
   const [confirmText, setConfirmText] = React.useState<string[]>([]);
   const [showAbout, setShowAbout] = React.useState<boolean>(false);
+  const [showBookshelf, setShowBookshelf] = React.useState<boolean>(false);
+  const [showAddBookshelf, setShowAddBookshelf] = React.useState<boolean>(false);
+  const [newBookshelfName, setNewBookshelfName] = React.useState<string>('');
+  const [bookshelfList, setBookshelfList] = props.bookshelfListState;
+  const [selectedBookshelf, setSelectedBookshelf] = props.selectedBookshelfState;
   const forceUpdate: () => void = React.useState({})[1].bind(null, {})
 
   return (
@@ -47,7 +54,7 @@ export function Menu(props: IMenuProps) {
         <Button
           className={css.menuItem}
           icon={'reuse'}
-          iconStyle={{fontSize: '0.9rem'}}
+          iconStyle={{ fontSize: '0.9rem' }}
           onClick={props.onSync}
         >
           同步
@@ -73,6 +80,13 @@ export function Menu(props: IMenuProps) {
           onClick={() => setShowAbout(true)}
         >
           关于
+        </Button>
+        <Button
+          className={css.menuItem}
+          icon={'menu'}
+          onClick={() => setShowBookshelf(n => !n)}
+        >
+          书架
         </Button>
       </ButtonGroup>
 
@@ -103,7 +117,7 @@ export function Menu(props: IMenuProps) {
           }
         }}
         cancel={() => setShowConfig(false)}
-        style={{with: '60%'}}
+        style={{ with: '60%' }}
       >
         {
           settings && (
@@ -114,7 +128,7 @@ export function Menu(props: IMenuProps) {
                     <FormItem status='normal'>
                       <Text value={settings.folder} disabled />
                     </FormItem>
-        
+
                     <FormItem>
                       <Button
                         onClick={() => {
@@ -132,8 +146,8 @@ export function Menu(props: IMenuProps) {
                   </FormGroup>
                 )
               }
-    
-              <FormGroup label="WebDAV" elementStyle={{flexFlow: 'column'}}>
+
+              <FormGroup label="WebDAV" elementStyle={{ flexFlow: 'column' }}>
                 <FormItem label="地址" status='normal'>
                   <Text
                     defaultValue={settings.webDav.url}
@@ -153,7 +167,7 @@ export function Menu(props: IMenuProps) {
                     }}
                   />
                 </FormItem>
-    
+
                 <FormItem label="密码" status='normal'>
                   <Text
                     defaultValue={settings.webDav.password}
@@ -165,7 +179,7 @@ export function Menu(props: IMenuProps) {
                   />
                 </FormItem>
               </FormGroup>
-            </Form>   
+            </Form>
           )
         }
       </Modal>
@@ -180,8 +194,8 @@ export function Menu(props: IMenuProps) {
           setShowConfirm(false);
         }}
         cancel={() => setShowConfirm(false)}
-        titleStyle={{color: 'red'}}
-        contentStyle={{color: 'red'}}
+        titleStyle={{ color: 'red' }}
+        contentStyle={{ color: 'red' }}
       >
         {
           confirmText.map(t => (
@@ -217,6 +231,60 @@ export function Menu(props: IMenuProps) {
             <p>本软件为自由软件，遵循协议</p>
             <a href="https://www.gnu.org/licenses/lgpl-3.0.html" target='_blank'>GNU Lesser General Public License (LGPL)</a>
           </div>
+        </div>
+      </Modal>
+      <Sidebar
+        open={showBookshelf}
+        style={{ width: '300px' }}
+      >
+        <button
+          className={`${css.bookshelfButton} ${selectedBookshelf ? '' : css.bookshelfButtonActive}`}
+          onClick={() => setSelectedBookshelf(null)}
+        >默认书架</button>
+        {bookshelfList.map(bookshelfName => (
+          <button
+            className={`${css.bookshelfButton} ${selectedBookshelf === bookshelfName ? css.bookshelfButtonActive : ''}`}
+            key={bookshelfName}
+            onClick={() => setSelectedBookshelf(bookshelfName)}
+          >{bookshelfName}</button>
+        ))}
+        <button
+          className={css.bookshelfButton}
+          style={{ borderBottom: 'none' }}
+          onClick={() => {
+            setShowAddBookshelf(true);
+          }}
+        >
+          <Icon type='plus' style={{ marginRight: '0.5rem' }} />
+          添加书架
+        </button>
+      </Sidebar>
+      <Modal
+        show={showAddBookshelf}
+        confirm={() => {
+          if (newBookshelfName.trim().length) {
+            if (bookshelfList.indexOf(newBookshelfName) >= 0 || newBookshelfName === '默认书架') {
+              alert('书架已存在！');
+              return;
+            }
+            setBookshelfList([...bookshelfList, newBookshelfName]);
+            setNewBookshelfName('');
+            setShowAddBookshelf(false);
+          }
+        }}
+        cancel={() => {
+          setShowAddBookshelf(false);
+          setNewBookshelfName('');
+        }}
+      >
+        <div>
+          <h3>添加书架</h3>
+          <hr />
+          <p>请输入书架名称</p>
+          <Text
+            value={newBookshelfName}
+            onChange={(e, _) => setNewBookshelfName((e.target as any).value)}
+          />
         </div>
       </Modal>
     </>

--- a/src/frontend/styles/books.module.scss
+++ b/src/frontend/styles/books.module.scss
@@ -130,3 +130,28 @@
     color: #6c9;
   }
 }
+
+.bookshelfButton {
+  width: 100%;
+  height: 2.5rem;
+  background-color: transparent;
+  border: none;
+  outline: none;
+  border-bottom: #111 solid 1px;
+  font-size: 1rem;
+  color: #444;
+  display: block;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.bookshelfButton:hover {
+  color: #6cd4a4;
+}
+
+.bookshelfButtonActive {
+  color: #6cd4a4;
+}

--- a/src/interfaces/protocols.ts
+++ b/src/interfaces/protocols.ts
@@ -43,4 +43,8 @@ export interface IBookConfig {
   notes: IBookNote[];
   // only remote
   removedTs?: {[cfi: string]: number};
+  bookshelf?: {
+    value: string | null;
+    ts: number;
+  };
 }


### PR DESCRIPTION
通过在IBookConfig中添加bookshelf属性实现对书籍的书架分类，不需要对原有数据结构做较大的更改便可实现书架功能，使新版本实现对原有数据的完美兼容。

bookshelf中包含value和ts两个属性，分别代表其所属的书架名称和书架属性更改时间戳，通过为bookshelf单独维护时间戳实现更细致的Config同步管理。

分文件更改介绍如下：
- src/frontend/App.tsx
    - 添加加载书架列表的功能，并在初始加载与手动同步时加载
- src/frontend/books/Books.tsx
    - 为每本书添加更改书架选项
    - 更改书架后向本地和云端同步
- src/frontend/books/Menu.tsx
    - 添加书架列表侧边栏
- src/frontend/styles/books.module.scss
    - 添加书架列表侧边栏样式
- src/frontend/webdav.ts
    - 添加bookshelf属性同步逻辑
    - 添加bookshelf属性读取/同步函数
- src/interfaces/protocols.ts
    - 为IBookConfig添加bookshelf属性

测试情况：
在Windows和Android上均进行了测试，由于没有iOS设备所以未在iOS上进行测试。